### PR TITLE
only show important branches (default, master, develop)

### DIFF
--- a/Script/ViewModels/BuildScreenViewModel.js
+++ b/Script/ViewModels/BuildScreenViewModel.js
@@ -67,9 +67,7 @@
                         branchFromApi.buildType = buildType;
                         branchFromApi.builds = getBuildsForBranchObservable(branchFromApi);
                         return branchFromApi;
-                    }).filter(function(branchFromApi) {
-                        return ["<default>", "master", "develop"].indexOf(branchFromApi.name) > -1;
-                    });
+                    }).filter(Settings.branchFilter || function() { return true; });
                 }
             });
         }

--- a/Script/ViewModels/BuildScreenViewModel.js
+++ b/Script/ViewModels/BuildScreenViewModel.js
@@ -67,6 +67,8 @@
                         branchFromApi.buildType = buildType;
                         branchFromApi.builds = getBuildsForBranchObservable(branchFromApi);
                         return branchFromApi;
+                    }).filter(function(branchFromApi) {
+                        return ["<default>", "master", "develop"].indexOf(branchFromApi.name) > -1;
                     });
                 }
             });

--- a/Settings.js
+++ b/Settings.js
@@ -26,6 +26,11 @@
 
     //use this to stop the screen from updating automatically at all (disables both appUpdateIntervalMs and dataUpdateIntervalMs). You will need to manually refresh the page to get new data.
     enableAutoUpdate: true,
+    
+    //Only show builds for branches that satisfy the predicate
+    branchFilter: function(branch) {
+        return ["<default>", "master", "develop"].indexOf(branch.name) > -1;
+    }
 }
 
 //Allow the settings to be overridden by querystring parameters


### PR DESCRIPTION
So we can focus on important builds, this change hides any builds that aren't based on one of the following branches:

* `<default>` (where the build configuration does not cover multiple branches)
* `master`
* `develop`

/cc @slawomir-brzezinski-at-travcorp @nigeltaylor-ttc